### PR TITLE
Adds support for whitespace chars in Datastore names on Windows

### DIFF
--- a/client_plugin/utils/fs/fs_windows.go
+++ b/client_plugin/utils/fs/fs_windows.go
@@ -47,18 +47,18 @@ const (
 			$instanceId = $_
 			$uiNum = (
 				Get-PnpDeviceProperty -InstanceId $instanceId -KeyName 'DEVPKEY_Device_UINumber' |
-				Select -expand Data -erroraction 'silentlycontinue'
+				Select -Expand Data -ErrorAction 'SilentlyContinue'
 			)
 			$addr = (
 				Get-PnpDeviceProperty -InstanceId $instanceId -KeyName 'DEVPKEY_Device_Address' |
-				Select -expand Data -erroraction 'silentlycontinue'
+				Select -Expand Data -ErrorAction 'SilentlyContinue'
 			)
 			If ($uiNum -eq '%s' -And $addr -eq '%s') {
 				Write-Host ""
 				Get-WmiObject Win32_DiskDrive |
 				Where-Object { $_.PNPDeviceId -eq $instanceId } |
 				Select-Object -ExpandProperty Index
-				exit
+				Exit
 			}
 		}
 		Write-Host ""
@@ -100,7 +100,7 @@ const (
 				$diskNum = $_.DiskNumber
 				Remove-PartitionAccessPath -DiskNumber $diskNum -PartitionNumber 1 -AccessPath "%s"
 				Write-Host $diskNum
-				exit
+				Exit
 			}
 		}
 		Write-Host "DiskNotFound"
@@ -275,11 +275,11 @@ func GetMountInfo(mountRoot string) (map[string]string, error) {
 	log.WithFields(log.Fields{"out": string(out)}).Info("List mounts script executed")
 
 	for _, line := range strings.Split(string(out), lf) {
-		fields := strings.Fields(line)
+		fields := strings.SplitN(line, " ", 2)
 		if len(fields) < 2 {
 			continue // skip empty line and lines too short to have our mount
 		}
-		for _, path := range fields[1:] {
+		for _, path := range strings.SplitN(fields[1], `\ `, -1) {
 			path = filepath.Clean(path) // remove trailing slash
 			if filepath.Dir(path) == mountRoot {
 				volumeMountMap[filepath.Base(path)] = fields[0]

--- a/esx_service/vmdk_ops_test.py
+++ b/esx_service/vmdk_ops_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2016 VMware, Inc. All Rights Reserved.
+# Copyright 2016-2017 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ class VolumeNamingTestCase(unittest.TestCase):
         """checks name parsing and error checks
         'volume[@datastore]' -> volume and datastore"""
         testInfo = [
-            #  [ full_name. expected_vol_name, expected_datastore_name,  expected_success? ]
+            #  [ full_name, expected_vol_name, expected_datastore_name,  expected_success? ]
             ["MyVolume123_a_.vol@vsanDatastore_11", "MyVolume123_a_.vol", "vsanDatastore_11", True],
             ["a1@x",                            "a1",                  "x",             True],
             ["a1",                              "a1",                  None,            True],
@@ -88,6 +88,7 @@ class VolumeNamingTestCase(unittest.TestCase):
                            "Just100Chars0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567", None, True],
             ["Volume.123@dots.dot",              "Volume.123",        "dots.dot",       True],
             ["simple_volume",                    "simple_volume",      None,            True],
+            ["spacesindatastore@local   .3 -   0", "spacesindatastore", "local   .3 -   0", True],
         ]
         for unit in testInfo:
             full_name, expected_vol_name, expected_ds_name, expected_result = unit


### PR DESCRIPTION
This PR adds handling to correctly map volumes with whitespace characters in its name. Testing was done manually i.e. a volume was created with <code>docker volume create --driver=vsphere "newvolume@local&nbsp;&nbsp;&nbsp;.3 -&nbsp;&nbsp;&nbsp;0"</code>, and attached with <code>docker run -it -v "newvolume@local&nbsp;&nbsp;&nbsp;.3 -&nbsp;&nbsp;&nbsp;0:C:/mountpoint/" microsoft/nanoserver powershell</code>, and the following log was observed.

```
time="2017-08-11T17:26:39Z" level=info msg="Successfully retrieved mounts" map=map[newvolume@local   .3 -   0:4]
```

See #1724 for original issue.