### PR TITLE
Fix checks for pci slot number to use lower case compares.

### DIFF
--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -1268,7 +1268,7 @@ def get_controller_pci_slot(vm, pvscsi, key_offset):
        key = 'scsi{0}.pciSlotNumber'.format(pvscsi.key -
                                             key_offset)
        slot = [cfg for cfg in vm.config.extraConfig \
-               if cfg.key == key]
+               if cfg.key.lower() == key.lower()]
        # If the given controller exists
        if slot:
           slot_num = slot[0].value
@@ -1285,7 +1285,7 @@ def get_controller_pci_slot(vm, pvscsi, key_offset):
         # Get PCI bridge slot number
         key = 'pciBridge{0}.pciSlotNumber'.format(bus)
         bridge_slot = [cfg for cfg in vm.config.extraConfig \
-                       if cfg.key == key]
+                       if cfg.key.lower() == key.lower()]
         if bridge_slot:
             slot_num = bridge_slot[0].value
         else:

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -1264,7 +1264,7 @@ def get_controller_pci_slot(vm, pvscsi, key_offset):
     if pvscsi.slotInfo:
        slot_num = pvscsi.slotInfo.pciSlotNumber
     else:
-       # Slot number is got from from the VM config
+       # Slot number is got from from the VM config.
        key = 'scsi{0}.pciSlotNumber'.format(pvscsi.key -
                                             key_offset)
        slot = [cfg for cfg in vm.config.extraConfig \


### PR DESCRIPTION
Fix has been tested locally and by reporter. Switch to use lower case compares when getting the slot/bus number for the pvscsi controller. 6.5 U1 seems to be use lower case key names in the VM config and hence causing the issue.