### PR TITLE
Restored DVOL_KEY to "docker-volume-vsphere"

### DIFF
--- a/esx_service/utils/kvESX.py
+++ b/esx_service/utils/kvESX.py
@@ -54,7 +54,7 @@ DISK_LIB64 = "/lib64/libvmsnapshot.so"
 DISK_LIB = "/lib/libvmsnapshot.so"
 lib = None
 use_sidecar_create = False
-DVOL_KEY = "vsphere-storage-for-docker"
+DVOL_KEY = "docker-volume-vsphere"
 
 # Volume attributes
 VOL_SIZE = 'size'


### PR DESCRIPTION
The change to rename the repo made at least one change in kvESX.py to set DVOL_KEY to the new repo name. This shouldn't have been done as the DVOL_KEY is hashed to create a unique name for the KV file for a container volume. Since it was changed, older KV files are not openable as the code is creating a new hash for the new value and hence a new file name.

Pls. merge this change asap.

All 0.21 users would be impacted as their older container volumes and hence data won't be accessible.

@shuklanirdesh82 can we release a patch or make a one-off release 0.22 to have this change out asap.
