### PR TITLE
Fix KV files on clone.

### DIFF
--- a/esx_service/utils/kvESX.py
+++ b/esx_service/utils/kvESX.py
@@ -315,7 +315,7 @@ def load(volpath):
     vol_type = get_vol_type(volpath)
     if not vol_type:
         logging.warning("KV delete - could not determine type of volume %s", volpath)
-        return False
+        return None
     if vol_type == c_uint32(KV_VOL_VIRTUAL).value:
         meta_file = lib.DiskLib_SidecarMakeFileName(volpath.encode(),
                                                     DVOL_KEY.encode())

--- a/esx_service/utils/kvESX.py
+++ b/esx_service/utils/kvESX.py
@@ -19,7 +19,8 @@ of a KV store for vmdks.
 
 from ctypes import \
         CDLL, POINTER, byref, Structure,\
-        c_char_p, c_int32, c_bool, c_uint32, c_uint64
+        c_char_p, c_int32, c_bool, c_uint32, c_uint64,\
+        create_string_buffer, addressof
 import json
 import logging
 import sys
@@ -48,6 +49,9 @@ KV_VOL_VIRTUAL = 2
 
 # Volume KV prop
 KV_VOL_DESC_PROP = "sidecars".encode()
+
+# KV file type
+KV_FILE_TYPE='sidecars'
 
 # VSphere lib to access ESX proprietary APIs.
 DISK_LIB64 = "/lib64/libvmsnapshot.so"
@@ -185,6 +189,26 @@ def kv_esx_init():
     disk_lib_init()
 
 
+def get_vol_type(volpath):
+    vol_type = c_uint32(0)
+    res = lib.ObjLib_PathToType(volpath.encode(), byref(vol_type))
+    if res != 0:
+        logging.warning("Could not determine type of volume %s, error - %x", volpath, res)
+        return None
+    return vol_type.value
+
+def get_kv_filename(volpath):
+    kv_type = KV_FILE_TYPE
+    with open(volpath) as f:
+        for line in f:
+            if KV_FILE_TYPE in line:
+                s=line.split(',')[1]
+                kv_file = s.split('"')[0]
+                return "{0}/{1}".format(os.path.dirname(volpath),
+                       kv_file)
+    return None
+
+
 @diskLibLock
 def vol_open_path(volpath, open_flags=VMDK_OPEN_DEFAULT):
     """
@@ -210,15 +234,12 @@ def create(volpath, kv_dict):
     """
     obj_handle = get_uint(0)
 
-    # If the volume is a virtual type then
-    # create the KV as a flat file.
-    vol_type = c_uint32(0)
-    res = lib.ObjLib_PathToType(volpath.encode(), byref(vol_type))
-    if res != 0:
+    # If the volume is a virtual type then the KV as a flat file.
+    vol_type = get_vol_type(volpath)
+    if not vol_type:
         logging.warning("Could not determine type of volume %s, error - %x", volpath, res)
         return False
-
-    if vol_type.value == c_uint32(KV_VOL_VIRTUAL).value:
+    if vol_type == c_uint32(KV_VOL_VIRTUAL).value:
         return save(volpath, kv_dict)
 
     dhandle = vol_open_path(volpath)
@@ -248,12 +269,11 @@ def delete(volpath):
     """
     Delete the side car for the given volume.
     """
-    vol_type = c_uint32(0)
-    res = lib.ObjLib_PathToType(volpath.encode(), byref(vol_type))
-    if res != 0:
+    vol_type = get_vol_type(volpath)
+    if not vol_type:
         logging.warning("KV delete - could not determine type of volume %s, error - %x", volpath, res)
         return False
-    if vol_type.value == c_uint32(KV_VOL_VIRTUAL).value:
+    if vol_type == c_uint32(KV_VOL_VIRTUAL).value:
         meta_file = lib.DiskLib_SidecarMakeFileName(volpath.encode(), DVOL_KEY.encode())
         if os.path.exists(meta_file):
             os.unlink(meta_file)
@@ -288,8 +308,17 @@ def load(volpath):
     """
     Load and return dictionary from the sidecar
     """
-    meta_file = lib.DiskLib_SidecarMakeFileName(volpath.encode(),
-                                                DVOL_KEY.encode())
+    vol_type = get_vol_type(volpath)
+    if not vol_type:
+        logging.warning("KV delete - could not determine type of volume %s, error - %x", volpath, res)
+        return False
+    if vol_type == c_uint32(KV_VOL_VIRTUAL).value:
+        meta_file = lib.DiskLib_SidecarMakeFileName(volpath.encode(),
+                                                    DVOL_KEY.encode())
+    else:
+        meta_file = get_kv_filename(volpath)
+        if not meta_file:
+            return None
     retry_count = 0
     vol_name = vmdk_utils.get_volname_from_vmdk_path(volpath)
     while True:
@@ -320,8 +349,18 @@ def save(volpath, kv_dict, key=None, value=None):
     """
     Save the dictionary to side car.
     """
-    meta_file = lib.DiskLib_SidecarMakeFileName(volpath.encode(),
-                                                DVOL_KEY.encode())
+    vol_type = get_vol_type(volpath)
+    if not vol_type:
+        logging.warning("KV delete - could not determine type of volume %s, error - %x", volpath, res)
+        return False
+    if vol_type == c_uint32(KV_VOL_VIRTUAL).value:
+        meta_file = lib.DiskLib_SidecarMakeFileName(volpath.encode(),
+                                                    DVOL_KEY.encode())
+    else:
+        meta_file = get_kv_filename(volpath)
+        if not meta_file:
+            return False
+
     kv_str = json.dumps(kv_dict)
 
     retry_count = 0
@@ -361,34 +400,37 @@ def fixup_kv(src_volpath, dst_volpath):
     Fix up the sidecars for the destination volume which ever is a
     volume of type - virtual.
     """
-    src_vol_type = c_uint32(0)
-    res = lib.ObjLib_PathToType(src_volpath.encode(), byref(src_vol_type))
-    if res != 0:
-        logging.warning("Could not determine type of volume %s, error - %x", src_volpath, res)
+    src_vol_type = get_vol_type(src_volpath)
+    logging.warning("Source vvol type %x", src_vol_type)
+    if not src_vol_type:
+        logging.warning("KV delete - could not determine type of volume %s, error - %x", volpath, res)
         return False
 
-    dst_vol_type = c_uint32(0)
-    res = lib.ObjLib_PathToType(dst_volpath.encode(), byref(dst_vol_type))
-    if res != 0:
-        logging.warning("Could not determine type of volume %s, error - %x", dst_volpath, res)
+    dst_vol_type = get_vol_type(dst_volpath)
+    logging.warning("Dest vvol type %x", src_vol_type)
+    if not dst_vol_type:
+        logging.warning("KV delete - could not determine type of volume %s, error - %x", volpath, res)
         return False
 
-    if src_vol_type.value != c_uint32(KV_VOL_VIRTUAL).value:
+    if src_vol_type != c_uint32(KV_VOL_VIRTUAL).value:
         # If the destination is a virtual type volume,
         # the source will create a native sidecar that must be deleted
         # and a new flat file version is created.
-        dhandle = vol_open_path(dst_volpath)
-        if not disk_is_valid(dhandle):
-            return False
-        res = lib.DiskLib_SidecarDelete(dhandle, DVOL_KEY.encode())
-        if res != 0:
-            logging.warning("Side car delete for %s failed - %x", dst_volpath, res)
+        if dst_vol_type == c_uint32(KV_VOL_VIRTUAL).value:
+            dhandle = vol_open_path(dst_volpath)
+            if not disk_is_valid(dhandle):
+                return False
+            res = lib.DiskLib_SidecarDelete(dhandle, DVOL_KEY.encode())
+            if res != 0:
+                logging.warning("Side car delete for %s failed - %x", dst_volpath, res)
+                lib.DiskLib_Close(dhandle)
+                return False
+    
             lib.DiskLib_Close(dhandle)
-            return False
-
-        lib.DiskLib_Close(dhandle)
-        src_dict = load(src_volpath)
-        return create(dst_volpath, src_dict)
+            src_dict = load(src_volpath)
+            return create(dst_volpath, src_dict)
+        else:
+            return True
     else:
         # The source is a virtual type volume, the destination
         # doesn't yet have a KV file, create it now. This is true

--- a/esx_service/utils/kvESX.py
+++ b/esx_service/utils/kvESX.py
@@ -199,13 +199,17 @@ def get_vol_type(volpath):
 
 def get_kv_filename(volpath):
     kv_type = KV_FILE_TYPE
-    with open(volpath) as f:
-        for line in f:
-            if KV_FILE_TYPE in line:
-                s=line.split(',')[1]
-                kv_file = s.split('"')[0]
-                return "{0}/{1}".format(os.path.dirname(volpath),
-                       kv_file)
+    try:
+        with open(volpath) as f:
+            for line in f:
+                if KV_FILE_TYPE in line:
+                    s=line.split(',')[1]
+                    kv_file = s.split('"')[0]
+                    return "{0}/{1}".format(os.path.dirname(volpath),
+                           kv_file)
+    except IOError as open_error:
+        logging.exception("Failed to open %s", volpath)
+        return None
     return None
 
 

--- a/esx_service/utils/kvESX.py
+++ b/esx_service/utils/kvESX.py
@@ -237,7 +237,7 @@ def create(volpath, kv_dict):
     # If the volume is a virtual type then the KV as a flat file.
     vol_type = get_vol_type(volpath)
     if not vol_type:
-        logging.warning("Could not determine type of volume %s, error - %x", volpath, res)
+        logging.warning("Could not determine type of volume %s", volpath)
         return False
     if vol_type == c_uint32(KV_VOL_VIRTUAL).value:
         return save(volpath, kv_dict)
@@ -271,7 +271,7 @@ def delete(volpath):
     """
     vol_type = get_vol_type(volpath)
     if not vol_type:
-        logging.warning("KV delete - could not determine type of volume %s, error - %x", volpath, res)
+        logging.warning("KV delete - could not determine type of volume %s", volpath)
         return False
     if vol_type == c_uint32(KV_VOL_VIRTUAL).value:
         meta_file = lib.DiskLib_SidecarMakeFileName(volpath.encode(), DVOL_KEY.encode())
@@ -310,7 +310,7 @@ def load(volpath):
     """
     vol_type = get_vol_type(volpath)
     if not vol_type:
-        logging.warning("KV delete - could not determine type of volume %s, error - %x", volpath, res)
+        logging.warning("KV delete - could not determine type of volume %s", volpath)
         return False
     if vol_type == c_uint32(KV_VOL_VIRTUAL).value:
         meta_file = lib.DiskLib_SidecarMakeFileName(volpath.encode(),
@@ -351,7 +351,7 @@ def save(volpath, kv_dict, key=None, value=None):
     """
     vol_type = get_vol_type(volpath)
     if not vol_type:
-        logging.warning("KV delete - could not determine type of volume %s, error - %x", volpath, res)
+        logging.warning("KV delete - could not determine type of volume %s", volpath)
         return False
     if vol_type == c_uint32(KV_VOL_VIRTUAL).value:
         meta_file = lib.DiskLib_SidecarMakeFileName(volpath.encode(),
@@ -403,13 +403,13 @@ def fixup_kv(src_volpath, dst_volpath):
     src_vol_type = get_vol_type(src_volpath)
     logging.warning("Source vvol type %x", src_vol_type)
     if not src_vol_type:
-        logging.warning("KV delete - could not determine type of volume %s, error - %x", volpath, res)
+        logging.warning("KV delete - could not determine type of volume %s", src_volpath)
         return False
 
     dst_vol_type = get_vol_type(dst_volpath)
     logging.warning("Dest vvol type %x", src_vol_type)
     if not dst_vol_type:
-        logging.warning("KV delete - could not determine type of volume %s, error - %x", volpath, res)
+        logging.warning("KV delete - could not determine type of volume %s", dst_volpath)
         return False
 
     if src_vol_type != c_uint32(KV_VOL_VIRTUAL).value:

--- a/esx_service/utils/kvESX.py
+++ b/esx_service/utils/kvESX.py
@@ -377,21 +377,18 @@ def fixup_kv(src_volpath, dst_volpath):
         # If the destination is a virtual type volume,
         # the source will create a native sidecar that must be deleted
         # and a new flat file version is created.
-        if dst_vol_type.value == c_uint32(KV_VOL_VIRTUAL).value:
-            dhandle = vol_open_path(dst_volpath)
-            if not disk_is_valid(dhandle):
-                return False
-            res = lib.DiskLib_SidecarDelete(dhandle, DVOL_KEY.encode())
-            if res != 0:
-                logging.warning("Side car delete for %s failed - %x", dst_volpath, res)
-                lib.DiskLib_Close(dhandle)
-                return False
-
+        dhandle = vol_open_path(dst_volpath)
+        if not disk_is_valid(dhandle):
+            return False
+        res = lib.DiskLib_SidecarDelete(dhandle, DVOL_KEY.encode())
+        if res != 0:
+            logging.warning("Side car delete for %s failed - %x", dst_volpath, res)
             lib.DiskLib_Close(dhandle)
-            src_dict = load(src_volpath)
-            return create(dst_volpath, src_dict)
-        else:
-            return True
+            return False
+
+        lib.DiskLib_Close(dhandle)
+        src_dict = load(src_volpath)
+        return create(dst_volpath, src_dict)
     else:
         # The source is a virtual type volume, the destination
         # doesn't yet have a KV file, create it now. This is true

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -365,7 +365,10 @@ def cloneVMDK(vm_name, vmdk_path, opts={}, vm_uuid=None, datastore_url=None, vm_
 
     vol_name = vmdk_utils.strip_vmdk_extension(src_vmdk_path.split("/")[-1])
 
-    # Fix up the KV for the destination
+    # Clone creates side cars with a random key and hence filename
+    # which need more work to figure out and use each time a volume
+    # op is performed. Remove the side car that hte clone created
+    # and create a new one.  Fix up the KV for the destination
     if not kv.fixup_kv(src_vmdk_path, vmdk_path):
         msg = ("Failed to create volume KV for %s" % vol_name)
         logging.warning(msg)

--- a/esx_service/vmdk_ops.py
+++ b/esx_service/vmdk_ops.py
@@ -367,7 +367,7 @@ def cloneVMDK(vm_name, vmdk_path, opts={}, vm_uuid=None, datastore_url=None, vm_
 
     # Clone creates side cars with a random key and hence filename
     # which need more work to figure out and use each time a volume
-    # op is performed. Remove the side car that hte clone created
+    # op is performed. Remove the side car that the clone created
     # and create a new one.  Fix up the KV for the destination
     if not kv.fixup_kv(src_vmdk_path, vmdk_path):
         msg = ("Failed to create volume KV for %s" % vol_name)


### PR DESCRIPTION
From ESX 6.5 onwards, the sidecars for the clone destination get created with a random key vs. the key thats used to create the source sidecars. Which is why the ESX service was unable to open and read/write the file after clone. Effectively clone was broken in 6.5 and later.

Fixed and now able to clone volumes fine.

docker volume ls
DRIVER              VOLUME NAME
vsphere:latest      test@datastore1

docker volume create -d vsphere clone -o clone-from=test
clone

docker volume inspect clone
[
    {
        "Driver": "vsphere:latest",
        "Labels": {},
        "Mountpoint": "/mnt/vmdk/clone/",
        "Name": "clone",
        "Options": {
            "clone-from": "test"
        },
        "Scope": "global",
        "Status": {
            "access": "read-write",
            "attach-as": "independent_persistent",
            "capacity": {
                "allocated": "13MB",
                "size": "100MB"
            },
            "clone-from": "test",
            "created": "Sun Mar 18 19:28:08 2018",
            "created by VM": "ubuntu-VM2.3 (1)",
            "datastore": "datastore1",
            "diskformat": "thin",
            "fstype": "ext4",
            "status": "detached"
        }
    }
]
