### PR TITLE
fix TLS 1.2 web request

### DIFF
--- a/install-vdvs.ps1
+++ b/install-vdvs.ps1
@@ -100,6 +100,7 @@ if ($svc) {
 
 # Download the vdvs binary
 echo "Downloading from $uri..."
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest $uri -OutFile $zipFileName
 if (! $?) {
     echo "Failed to download from $uri."


### PR DESCRIPTION
```
 .\install-vdvs.ps1 https://bintray.com/vmware/vDVS/download_file?file_path=vsphere-storage-for-docker_windows_0.21.zip

Downloading from https://bintray.com/vmware/vDVS/download_file?file_path=vsphere-storage-for-docker_windows_0.21.zip...
Invoke-WebRequest : The underlying connection was closed: An unexpected error occurred on a send.
At C:\Users\Joseph Petersen\install-vdvs.ps1:103 char:1
+ Invoke-WebRequest $uri -OutFile $zipFileName
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

Failed to download from https://bintray.com/vmware/vDVS/download_file?file_path=vsphere-storage-for-docker_windows_0.21.zip.
```